### PR TITLE
Rename ECXXX algorithm and related functions to ESXXX

### DIFF
--- a/jwt-ecdsa/README.md
+++ b/jwt-ecdsa/README.md
@@ -13,9 +13,9 @@ Sign and verify JWTs using ECDSA algorithm.
 
 ## Supported Algorithms
 
-- E2256
-- E2384
-- E2512
+- ES256
+- ES384
+- ES512
 
 ## Usage
 

--- a/jwt-ecdsa/README.md
+++ b/jwt-ecdsa/README.md
@@ -13,9 +13,9 @@ Sign and verify JWTs using ECDSA algorithm.
 
 ## Supported Algorithms
 
-- EC256
-- EC384
-- EC512
+- E2256
+- E2384
+- E2512
 
 ## Usage
 
@@ -40,10 +40,10 @@ val keys = CryptographyProvider.Default.get(ECDSA).keyPairGenerator(curve).gener
 val privateKey = keys.privateKey.encodeTo(EC.PrivateKey.Format.PEM)
 
 val signedJWT = jwt.sign {
-    ec256 { secret = pem(privateKey) }
+    es256 { secret = pem(privateKey) }
     // or with different hashing
-    // ec384 { secret = pem(privateKey) }
-    // ec512 { secret = pem(privateKey) }
+    // es384 { secret = pem(privateKey) }
+    // es512 { secret = pem(privateKey) }
 }
 ```
 
@@ -55,10 +55,10 @@ val keys = CryptographyProvider.Default.get(ECDSA).keyPairGenerator(curve).gener
 val publicKey = keys.publicKey.encodeTo(EC.PublicKey.Format.PEM)
 
 val isValid = jwt.verify {
-    ec256 { secret = pem(publicKey) }
+    es256 { secret = pem(publicKey) }
     // or with different hashing
-    // ec384 { secret = pem(publicKey) }
-    // ec512 { secret = pem(publicKey) }
+    // es384 { secret = pem(publicKey) }
+    // es512 { secret = pem(publicKey) }
 
     // verify issuer
     issuer("example.com")

--- a/jwt-ecdsa/api/android/jwt-ecdsa-kt.api
+++ b/jwt-ecdsa/api/android/jwt-ecdsa-kt.api
@@ -1,10 +1,10 @@
 public final class com/appstractive/jwt/signatures/ECDSAKt {
-	public static final fun ec256 (Lcom/appstractive/jwt/Signer;Lkotlin/jvm/functions/Function1;)V
-	public static final fun ec256 (Lcom/appstractive/jwt/Verifier;Lkotlin/jvm/functions/Function1;)V
-	public static final fun ec384 (Lcom/appstractive/jwt/Signer;Lkotlin/jvm/functions/Function1;)V
-	public static final fun ec384 (Lcom/appstractive/jwt/Verifier;Lkotlin/jvm/functions/Function1;)V
-	public static final fun ec512 (Lcom/appstractive/jwt/Signer;Lkotlin/jvm/functions/Function1;)V
-	public static final fun ec512 (Lcom/appstractive/jwt/Verifier;Lkotlin/jvm/functions/Function1;)V
+	public static final fun es256 (Lcom/appstractive/jwt/Signer;Lkotlin/jvm/functions/Function1;)V
+	public static final fun es256 (Lcom/appstractive/jwt/Verifier;Lkotlin/jvm/functions/Function1;)V
+	public static final fun es384 (Lcom/appstractive/jwt/Signer;Lkotlin/jvm/functions/Function1;)V
+	public static final fun es384 (Lcom/appstractive/jwt/Verifier;Lkotlin/jvm/functions/Function1;)V
+	public static final fun es512 (Lcom/appstractive/jwt/Signer;Lkotlin/jvm/functions/Function1;)V
+	public static final fun es512 (Lcom/appstractive/jwt/Verifier;Lkotlin/jvm/functions/Function1;)V
 }
 
 public final class com/appstractive/jwt/signatures/ECDSASignerConfig {

--- a/jwt-ecdsa/api/jvm/jwt-ecdsa-kt.api
+++ b/jwt-ecdsa/api/jvm/jwt-ecdsa-kt.api
@@ -1,10 +1,10 @@
 public final class com/appstractive/jwt/signatures/ECDSAKt {
-	public static final fun ec256 (Lcom/appstractive/jwt/Signer;Lkotlin/jvm/functions/Function1;)V
-	public static final fun ec256 (Lcom/appstractive/jwt/Verifier;Lkotlin/jvm/functions/Function1;)V
-	public static final fun ec384 (Lcom/appstractive/jwt/Signer;Lkotlin/jvm/functions/Function1;)V
-	public static final fun ec384 (Lcom/appstractive/jwt/Verifier;Lkotlin/jvm/functions/Function1;)V
-	public static final fun ec512 (Lcom/appstractive/jwt/Signer;Lkotlin/jvm/functions/Function1;)V
-	public static final fun ec512 (Lcom/appstractive/jwt/Verifier;Lkotlin/jvm/functions/Function1;)V
+	public static final fun es256 (Lcom/appstractive/jwt/Signer;Lkotlin/jvm/functions/Function1;)V
+	public static final fun es256 (Lcom/appstractive/jwt/Verifier;Lkotlin/jvm/functions/Function1;)V
+	public static final fun es384 (Lcom/appstractive/jwt/Signer;Lkotlin/jvm/functions/Function1;)V
+	public static final fun es384 (Lcom/appstractive/jwt/Verifier;Lkotlin/jvm/functions/Function1;)V
+	public static final fun es512 (Lcom/appstractive/jwt/Signer;Lkotlin/jvm/functions/Function1;)V
+	public static final fun es512 (Lcom/appstractive/jwt/Verifier;Lkotlin/jvm/functions/Function1;)V
 }
 
 public final class com/appstractive/jwt/signatures/ECDSASignerConfig {

--- a/jwt-ecdsa/src/commonMain/kotlin/com/appstractive/jwt/signatures/ECDSA.kt
+++ b/jwt-ecdsa/src/commonMain/kotlin/com/appstractive/jwt/signatures/ECDSA.kt
@@ -12,50 +12,50 @@ import dev.whyoleg.cryptography.operations.signature.SignatureVerifier
 internal val provider by lazy { CryptographyProvider.Default }
 internal val ecdsa: ECDSA by lazy { provider.get(ECDSA) }
 
-fun Signer.ec256(configure: ECDSASignerConfig.() -> Unit) {
+fun Signer.es256(configure: ECDSASignerConfig.() -> Unit) {
   val config = ECDSASignerConfig().apply(configure)
   algorithm(
       algorithm = ECDSASigner(config = config),
-      type = Algorithm.EC256,
+      type = Algorithm.ES256,
   )
 }
 
-fun Signer.ec384(configure: ECDSASignerConfig.() -> Unit) {
+fun Signer.es384(configure: ECDSASignerConfig.() -> Unit) {
   val config = ECDSASignerConfig().apply(configure)
   algorithm(
       algorithm = ECDSASigner(config = config),
-      type = Algorithm.EC384,
+      type = Algorithm.ES384,
   )
 }
 
-fun Signer.ec512(configure: ECDSASignerConfig.() -> Unit) {
+fun Signer.es512(configure: ECDSASignerConfig.() -> Unit) {
   val config = ECDSASignerConfig().apply(configure)
   algorithm(
       algorithm = ECDSASigner(config = config),
-      type = Algorithm.EC512,
+      type = Algorithm.ES512,
   )
 }
 
-fun Verifier.ec256(configure: ECDSAVerifierConfig.() -> Unit) {
+fun Verifier.es256(configure: ECDSAVerifierConfig.() -> Unit) {
   val config = ECDSAVerifierConfig().apply(configure)
   algorithm(
-      type = Algorithm.EC256,
+      type = Algorithm.ES256,
       algorithm = ECDSAVerifier(config = config),
   )
 }
 
-fun Verifier.ec384(configure: ECDSAVerifierConfig.() -> Unit) {
+fun Verifier.es384(configure: ECDSAVerifierConfig.() -> Unit) {
   val config = ECDSAVerifierConfig().apply(configure)
   algorithm(
-      type = Algorithm.EC384,
+      type = Algorithm.ES384,
       algorithm = ECDSAVerifier(config = config),
   )
 }
 
-fun Verifier.ec512(configure: ECDSAVerifierConfig.() -> Unit) {
+fun Verifier.es512(configure: ECDSAVerifierConfig.() -> Unit) {
   val config = ECDSAVerifierConfig().apply(configure)
   algorithm(
-      type = Algorithm.EC512,
+      type = Algorithm.ES512,
       algorithm = ECDSAVerifier(config = config),
   )
 }

--- a/jwt-ecdsa/src/commonTest/kotlin/com/appstractive/jwt/signatures/JwtVerifierTests.kt
+++ b/jwt-ecdsa/src/commonTest/kotlin/com/appstractive/jwt/signatures/JwtVerifierTests.kt
@@ -11,36 +11,36 @@ import kotlinx.coroutines.test.runTest
 class JwtVerifierTests {
 
   @Test
-  fun createJwtEC256() = runTest {
+  fun createJwtES256() = runTest {
     val jwt =
         createJwtEC(
-            builder = { ec256 { pem(it) } },
-            verifier = { ec256 { pem(it) } },
+            builder = { es256 { pem(it) } },
+            verifier = { es256 { pem(it) } },
         )
 
-    assertEquals(Algorithm.EC256, jwt.header.alg)
+    assertEquals(Algorithm.ES256, jwt.header.alg)
   }
 
   @Test
-  fun createJwtEC384() = runTest {
+  fun createJwtES384() = runTest {
     val jwt =
         createJwtEC(
-            builder = { ec384 { pem(it) } },
-            verifier = { ec384 { pem(it) } },
+            builder = { es384 { pem(it) } },
+            verifier = { es384 { pem(it) } },
         )
 
-    assertEquals(Algorithm.EC384, jwt.header.alg)
+    assertEquals(Algorithm.ES384, jwt.header.alg)
   }
 
   @Test
-  fun createJwtEC512() = runTest {
+  fun createJwtES512() = runTest {
     val jwt =
         createJwtEC(
-            builder = { ec512 { pem(it) } },
-            verifier = { ec512 { pem(it) } },
+            builder = { es512 { pem(it) } },
+            verifier = { es512 { pem(it) } },
         )
 
-    assertEquals(Algorithm.EC512, jwt.header.alg)
+    assertEquals(Algorithm.ES512, jwt.header.alg)
   }
 
   private suspend fun createJwtEC(

--- a/jwt/api/android/jwt-kt.api
+++ b/jwt/api/android/jwt-kt.api
@@ -1,7 +1,7 @@
 public final class com/appstractive/jwt/Algorithm : java/lang/Enum {
-	public static final field EC256 Lcom/appstractive/jwt/Algorithm;
-	public static final field EC384 Lcom/appstractive/jwt/Algorithm;
-	public static final field EC512 Lcom/appstractive/jwt/Algorithm;
+	public static final field ES256 Lcom/appstractive/jwt/Algorithm;
+	public static final field ES384 Lcom/appstractive/jwt/Algorithm;
+	public static final field ES512 Lcom/appstractive/jwt/Algorithm;
 	public static final field HS256 Lcom/appstractive/jwt/Algorithm;
 	public static final field HS384 Lcom/appstractive/jwt/Algorithm;
 	public static final field HS512 Lcom/appstractive/jwt/Algorithm;

--- a/jwt/api/jvm/jwt-kt.api
+++ b/jwt/api/jvm/jwt-kt.api
@@ -1,7 +1,7 @@
 public final class com/appstractive/jwt/Algorithm : java/lang/Enum {
-	public static final field EC256 Lcom/appstractive/jwt/Algorithm;
-	public static final field EC384 Lcom/appstractive/jwt/Algorithm;
-	public static final field EC512 Lcom/appstractive/jwt/Algorithm;
+	public static final field ES256 Lcom/appstractive/jwt/Algorithm;
+	public static final field ES384 Lcom/appstractive/jwt/Algorithm;
+	public static final field ES512 Lcom/appstractive/jwt/Algorithm;
 	public static final field HS256 Lcom/appstractive/jwt/Algorithm;
 	public static final field HS384 Lcom/appstractive/jwt/Algorithm;
 	public static final field HS512 Lcom/appstractive/jwt/Algorithm;

--- a/jwt/src/commonMain/kotlin/com/appstractive/jwt/Signing.kt
+++ b/jwt/src/commonMain/kotlin/com/appstractive/jwt/Signing.kt
@@ -19,25 +19,25 @@ enum class Algorithm {
   PS256,
   PS384,
   PS512,
-  EC256,
-  EC384,
-  EC512,
+  ES256,
+  ES384,
+  ES512,
 }
 
 val Algorithm.digest: CryptographyAlgorithmId<Digest>
   get() =
       when (this) {
-        Algorithm.EC256,
+        Algorithm.ES256,
         Algorithm.PS256,
         Algorithm.RS256,
         Algorithm.HS256 -> SHA256
 
-        Algorithm.EC384,
+        Algorithm.ES384,
         Algorithm.RS384,
         Algorithm.PS384,
         Algorithm.HS384 -> SHA384
 
-        Algorithm.EC512,
+        Algorithm.ES512,
         Algorithm.HS512,
         Algorithm.RS512,
         Algorithm.PS512 -> SHA512


### PR DESCRIPTION
The ECDSA signer and verifier use an `alg` header with `EC256` instead of `ES256` (analogous for 384 and 512). 
This prevents processing of JWTs produced by other signers as they write and expect the standard conforming value.

This patch renames all of the occurrences of ECXXX to ESXXX.
